### PR TITLE
Add symbol import command and csv output

### DIFF
--- a/coin_gecko_symbols_to_ids.json
+++ b/coin_gecko_symbols_to_ids.json
@@ -153,5 +153,10 @@
         "id": "terrausd",
         "symbol": "ustc",
         "name": "TerraClassicUSD"
+    },
+    "ETH": {
+        "id": "ethereum",
+        "symbol": "eth",
+        "name": "Ethereum"
     }
 }

--- a/staking-rewards.py
+++ b/staking-rewards.py
@@ -516,7 +516,15 @@ def import_symbol_coingecko_worker(symbol, config_file):
     for symbol_config in data:
         if symbol in symbol_config["symbol"] or symbol.lower() in symbol_config["symbol"]:
             possible_options.append(symbol_config)
+
+    if len(possible_options) == 0:
+        print(f"No options found that match symbol {symbol}")
+        print("If this sounds like an error, you can try manually looking through the JSON file provided by CoinGecko at:")
+        print(COIN_GECKO_API_URL + COIN_GECKO_COINS_ENDPOINT + COIN_GECKO_COINS_LIST_ENDPOINT)
+        return
+    
     print(f"Found {len(possible_options)} possible options for symbol {symbol}")
+
     print("Ranking them by least likely to most likely, this may take a second...")
 
     #Rank possible options from least likely to most likely


### PR DESCRIPTION
This one changes the CLI interface pretty heavily:

1. Add a subcommand `process` that does the original script
2. Add a subcommand `import-symbol` that takes in a single symbol to search CoinGecko for, then provides a UI for choosing an option to import into the specified CoinGecko config file
3. Adds an output parameter to the `process` command to specify CSV or XLSX output, defaults to CSV

Examples of the new command interfaces:

Process:
```
python staking-rewards.py process -i history.xlsx -o out.csv -cgstoid coin_gecko_symbols_to_ids.json -chstoid coinhall_symbols_to_ids.json -cg-c .coingecko_cache.json
```

Import:
```
python staking-rewards.py import-symbol ETH --type coingecko -cf coin_gecko_symbols_to_ids.json
```